### PR TITLE
bug: Fix the size not being reset to 0 when the cache clears itself

### DIFF
--- a/src/angular-cache.js
+++ b/src/angular-cache.js
@@ -94,8 +94,11 @@
                 if (config.cacheFlushInterval) {
                     config.cacheFlushIntervalId = setInterval(function () {
                         for (var key in data) {
-                            clearTimeout(data[key].timeoutId);
+                            if (data[key].timeoutId) {
+                                clearTimeout(data[key].timeoutId);
+                            }
                         }
+                        size = 0;
                         data = {};
                         lruHash = {};
                         freshEnd = null;


### PR DESCRIPTION
When the cacheFlushInterval is set the cache wasn't reseting its size when it cleared itself.

fixes #14 
