### PR TITLE
Upgrade grunt browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "mocha": "~1.17.1",
     "karma-mocha": "~0.1.1",
     "browserify": "~3.30.1",
-    "grunt-browserify": "~1.3.1",
+    "grunt-browserify": "~2.1.3",
     "bower": "~1.2.8",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-docular": "~0.1.2",


### PR DESCRIPTION
Since grunt browserify 2.1.1 https://github.com/jmreidy/grunt-browserify#v211 it "Properly append semicolons to bundle output"

This fixes https://github.com/jmdobry/angular-cache/issues/118 and https://github.com/jmdobry/angular-cache/issues/120
