### PR TITLE
stringifyNumber(0) fails to stringify

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -3,7 +3,7 @@ module.exports = {
    * Stringify a number.
    */
   stringifyNumber: function (number) {
-    if (number && angular.isNumber(number)) {
+    if (angular.isNumber(number)) {
       return number.toString();
     }
     return number;


### PR DESCRIPTION
I have to work my way with a legacy API that allows `0` as a valid `id` (don't ask). When wrapping this API with angular-data I bumped into:

http://errors.angularjs.org/1.2.25/ng/areq?p0=Expected%20key%20to%20be%20a%20string!%20Found%3A%20%7B0%7D.&p1=number

After applying this patch things started working.
