### PR TITLE
Return if item is still null

### DIFF
--- a/dist/angular-cache.js
+++ b/dist/angular-cache.js
@@ -342,6 +342,10 @@
           item = $$data[key];
         }
 
+        if (!item) {
+          return;
+        }
+
         var value = item.value;
         var now = new Date().getTime();
 


### PR DESCRIPTION
When writing some tests for another project, I was getting errors from angular-cache that item.value was undefined. I didn't do a whole lot of investigation into why, but this little change fixed it for me.